### PR TITLE
Add support for multisite-install

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -6,16 +6,15 @@ define wp::site (
 	$admin_email    = 'admin@example.com',
 	$admin_password = 'password',
 	$network        = false,
-	$subdomains     = false,
-	$base           = '/'
+	$subdomains     = false
 ) {
 	include wp::cli
 
 	if ( $network == true ) and ( $subdomains == true ) {
-		$install = "multisite-install --subdomains --base='$base'"
+		$install = "multisite-install --subdomains --base='$url'"
 	}
 	elsif ( $network == true ) {
-		$install = "multisite-install --base='$base'"
+		$install = "multisite-install --base='$url'"
 	}
 	else {
 		$install = "install --url='$url'"


### PR DESCRIPTION
Should also support multisite installs.
- I'm not sure if base is actually necessary
- URL is unused for multisite installs, but is still a required attribute because I didn't know what to set as a default. There's nothing really awesome you can set for it. I guess example.com? Or we could just keep it as a required attribute. Thoughts?

I'm happy to make any necessary change, but I think this is pretty solid.
