### PR TITLE
Install the plugin if it doesn't exist yet

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -12,7 +12,7 @@ define wp::plugin (
 			exec { "wp install plugin $title":
 				cwd     => $location,
 				command => "/usr/bin/wp plugin install $title",
-				unless  => "/usr/bin/wp plugin status $title",
+				unless  => "/usr/bin/wp plugin is-installed $title",
 				before  => Wp::Command["$location plugin $title $ensure"],
 				require => Class["wp::cli"],
 				onlyif  => "/usr/bin/wp core is-installed"


### PR DESCRIPTION
There should be a way to install a plugin if it doesn't exist. Ideally ensure = enabled would install it too. For example, this is how packages work. There's currently no WP-CLI command to check if a plugin is installed so the `unless` isn't great here. I'm going to try to submit a pull request for `plugin is-installed` to https://github.com/wp-cli/wp-cli/issues/627 some time this week. Other than the `unless`, I think this is pretty good.
