### PR TITLE
Make the wp-cli install actually complete

### DIFF
--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -34,7 +34,9 @@ class wp::cli (
 			command => "/usr/bin/yes | $install_path/installer.sh",
 			environment => [
 				"VERSION=$version",
-				"INSTALL_DIR=$install_path"
+				"INSTALL_DIR=$install_path",
+				"COMPOSER_HOME=$install_path",
+
 			],
 			require => [
 				File[ "$install_path/installer.sh" ],


### PR DESCRIPTION
This has to be set, otherwise wp-cli install routine ends up returning a `1` instead of a `0`, Puppet freaks out and thinks the install failed and so all downstream interactions that reply upon it being installed fail as a broken dependency.
