### PR TITLE
Add Download and Config Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,18 @@ commands as well as installing the WP CLI binaries as needed.
 ## Usage
 
 	# Setup the site
+	wp::download { '/vagrant/wp': }
+	wp::config { '/vagrant/wp':
+		dbname => $db_name,
+		dbuser => $db_user,
+		dbpass => $db_pass,
+		require => Wp::Download['/vagrant/wp']
+	}
 	wp::site {'/vagrant/wp':
 		# location => '/vagrant/wp',
 		url => 'http://wordpress.local',
 		name => 'Test Site',
-		require => Mysql::Db['store']
+		require => [ Mysql::Db['store'], Wp::Config['/vagrant/wp'] ]
 	}
 		wp::rewrite {'/%post_id%/%postname%/':
 			# structure => '/%post_id%/%postname%/',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,0 +1,42 @@
+define wp::config (
+	$location = $title,
+	$dbname,
+	$dbuser,
+	$dbpass,
+	$dbhost			= false,
+	$dbprefix		= false,
+	$dbcharset		= false,
+	$dbcollate		= false,
+	$locale			= false
+) {
+	include wp::cli
+
+	$config = ''
+
+	if ( $dbhost != false ) {
+		$config += "--dbhost='$dbhost' "
+	}
+
+	if ( $dbprefix != false ) {
+		$config += "--dbprefix='$dbprefix' "
+	}
+
+	if ( $dbcharset != false ) {
+		$config += "--dbcharset='$dbcharset' "
+	}
+
+	if ( $dbcollate != false ) {
+		$config += "--dbcollate='$dbcollate' "
+	}
+
+	if ( $locale != false ) {
+		$config += "--locale='$locale' "
+	}
+
+	exec {"wp core config":
+		command => "/usr/bin/wp core config --dbname='$dbname' --dbuser='$dbuser' --dbpass='$dbpass' $config",
+		cwd => $location,
+		require => [ Class['wp::cli'] ],
+		creates => "$location/wp-config.php"
+	}
+}

--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -24,6 +24,6 @@ define wp::download (
 		command => "/usr/bin/wp core download $download",
 		cwd => $location,
 		require => [ Class['wp::cli'] ],
-		creates => $location
+		creates => [ "$location/wp-admin", "$location/wp-content", "$location/wp-includes" ]
 	}
 }

--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -1,0 +1,29 @@
+define wp::download (
+	$location = $title,
+	$locale         = false,
+	$version        = false,
+	$force          = false
+) {
+	include wp::cli
+
+	$download = ''
+
+	if ( $locale != false ) {
+		$download += "--locale='$locale' "
+	}
+
+	if ( $version != false ) {
+		$download += "--version='$version' "
+	}
+
+	if ( $force != false ) {
+		$download += "--force"
+	}
+
+	exec {"wp core download":
+		command => "/usr/bin/wp core download $download",
+		cwd => $location,
+		require => [ Class['wp::cli'] ],
+		creates => $location
+	}
+}


### PR DESCRIPTION
Add support to download WP to a location as well as generate wp-config.php both using wp-cli.

Not perfect, some pieces may be better handled in a different way but this worked well in my testing. From a blank Ubuntu box to running WP.

Related to #2
