### PR TITLE
Use `--url` instead of `--site` for multisite installs

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -12,10 +12,10 @@ define wp::site (
 	include wp::cli
 
 	if ( $network == true ) and ( $subdomains == true ) {
-		$install = "multisite-install --subdomains --base='$url'"
+		$install = "multisite-install --subdomains --url='$url'"
 	}
 	elsif ( $network == true ) {
-		$install = "multisite-install --base='$url'"
+		$install = "multisite-install --url='$url'"
 	}
 	else {
 		$install = "install --url='$url'"


### PR DESCRIPTION
See #3. Looks like we really wanted `--url` not `--site` here.

Waiting on @joshbetz's approval for this, since he wrote the original.
