### PR TITLE
Download installer script from Github

### DIFF
--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -18,9 +18,8 @@ class wp::cli (
 
 		# Clone the Git repo
 		exec{ 'wp-cli download':
-			command => "/usr/bin/curl http://wp-cli.org/installer.sh -o $install_path/installer.sh",
+			command => "/usr/bin/curl https://raw.github.com/wp-cli/wp-cli.github.com/master/installer.sh -o $install_path/installer.sh",
 			require => [ Package[ 'curl' ], File[ $install_path ] ],
-			creates => "$install_path/installer.sh",
 		}
 
 		# Ensure we can run the installer


### PR DESCRIPTION
I've been seeing intermittent issues where VIP Quickstart is having issues downloading the installer script from wp-cli.org. It seems to be fixed by downloading directly from Github instead. Additionally, we should probably re-download the installer each time. If there's an issue downloading it and a blank file gets created, it would be stuck with a blank installer forever unless you manually delete it.
