### PR TITLE
Defined type duplication fix

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -1,4 +1,5 @@
 define wp::plugin (
+	$slug = $title,
 	$location,
 	$ensure = enabled,
 	$networkwide = false
@@ -7,19 +8,19 @@ define wp::plugin (
 
 	case $ensure {
 		enabled: {
-			$command = "activate $title"
+			$command = "activate $slug"
 
 			exec { "wp install plugin $title":
 				cwd     => $location,
-				command => "/usr/bin/wp plugin install $title",
-				unless  => "/usr/bin/wp plugin is-installed $title",
-				before  => Wp::Command["$location plugin $title $ensure"],
+				command => "/usr/bin/wp plugin install $slug",
+				unless  => "/usr/bin/wp plugin is-installed $slug",
+				before  => Wp::Command["$location plugin $slug $ensure"],
 				require => Class["wp::cli"],
 				onlyif  => "/usr/bin/wp core is-installed"
 			}
 		}
 		disabled: {
-			$command = "deactivate $title"
+			$command = "deactivate $slug"
 		}
 		default: {
 			fail("Invalid ensure for wp::plugin")
@@ -32,7 +33,7 @@ define wp::plugin (
 	else {
 		$args = "plugin $command"
 	}
-	wp::command { "$location plugin $title $ensure":
+	wp::command { "$location plugin $slug $ensure":
 		location => $location,
 		command => $args
 	}


### PR DESCRIPTION
No idea where else this might occur -- I'm thinking `theme.pp` might also have something similar, in which case I'll look to fix.

Long and short of it, though, is that you need to allow defined types to have unique resource names. Using `$title` as your Wp::Plugin `$name` means that anything downstream trying to define multiple Plugins runs into [this issue](http://docs.puppetlabs.com/learning/definedtypes.html#special-little-flowers), _hard_. Adding another parameter, `$slug`, allows us to sidestep this.

This is particularly important if you're provisioning several VirtualHosts/sites on a single install and you want identical plugin loadouts. 

This change allows me to do the following:

```
    wp::plugin {
#       [ "developer", "theme-check", "monster-widget", "debogger", "log-deprecated-notices",
#       "debug-bar" ]:
        "${install_path} Developer":
            slug        => "developer",
            location    => "$install_path",
            require     => Wp::Site[$install_path];
        "${install_path} Theme Check":
            slug        => "theme-check",
            location    => "$install_path",
            require     => Wp::Site[$install_path];     
    }
```

The commented-out invocation previously caused errors like

```
Error: Duplicate declaration: Exec[wp install plugin developer] is already declared in file /tmp/vagrant-puppet-1/modules-0/wp/manifests/plugin.pp at line 20; cannot redeclare on node localhost.localdomain
Error: Duplicate declaration: Exec[wp install plugin developer] is already declared in file /tmp/vagrant-puppet-1/modules-0/wp/manifests/plugin.pp at line 20; cannot redeclare on node localhost.localdomain
```

on my Vagrant builds.
