### PR TITLE
Create a site for real

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -21,10 +21,17 @@ define wp::site (
 		$install = "install --url='$url'"
 	}
 
+	exec {"wp download $location":
+		command => "/usr/bin/wp core download",
+		cwd => $location,
+		require => [ Class['wp::cli'] ],
+		unless => '/usr/bin/wp core is-installed'
+	}
+
 	exec {"wp install $location":
 		command => "/usr/bin/wp core $install --title='$sitename' --admin_email='$admin_email' --admin_name='$admin_user' --admin_password='$admin_password'",
 		cwd => $location,
-		require => [ Class['wp::cli'] ],
+		require => [ Class['wp::cli'], Exec["wp download $location"] ],
 		unless => '/usr/bin/wp core is-installed'
 	}
 


### PR DESCRIPTION
Default code only attempts an install. Without the download predicate, it will bomb. Open to checks other than `is-installed`.
