### PR TITLE
Allow running WP CLI as non-root

### DIFF
--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -3,6 +3,8 @@ class wp::cli (
 	$install_path = '/usr/local/src/wp-cli',
 	$version = 'dev-master'
 ) {
+	include wp
+
 	$phpprefix = $::operatingsystem ? {
 		'RedHat'		=> 'php',
 		'CentOS'		=> 'php',

--- a/manifests/command.pp
+++ b/manifests/command.pp
@@ -7,6 +7,7 @@ define wp::command (
 	exec {"$location wp $command":
 		command => "/usr/bin/wp $command",
 		cwd => $location,
+		user => $::wp::user,
 		require => [ Class['wp::cli'] ],
 		onlyif => '/usr/bin/wp core is-installed'
 	}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,0 +1,5 @@
+class wp (
+	$user = $::wp::params::user,
+) inherits wp::params {
+	# ...
+}

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -24,6 +24,7 @@ define wp::site (
 	exec {"wp install $location":
 		command => "/usr/bin/wp core $install --title='$sitename' --admin_email='$admin_email' --admin_name='$admin_user' --admin_password='$admin_password'",
 		cwd => $location,
+		user => $::wp::user,
 		require => [ Class['wp::cli'] ],
 		unless => '/usr/bin/wp core is-installed'
 	}
@@ -32,6 +33,7 @@ define wp::site (
 		wp::option {"wp siteurl $location":
 			location => $location,
 			ensure => "equal",
+			user => $::wp::user,
 
 			key => "siteurl",
 			value => $siteurl


### PR DESCRIPTION
See #18 for discussion. This fixes it in a slightly different way, by adding defaults.

To override the user:

``` puppet
class { 'wp':
    user => 'my-user',
}
```
