### PR TITLE
Theme and plugin manifest tweaks

### DIFF
--- a/manifests/command.pp
+++ b/manifests/command.pp
@@ -1,6 +1,8 @@
 define wp::command (
 	$location,
-	$command
+	$command,
+	$onlyif  = [],
+	$unless  = [],
 ) {
 	include wp::cli
 
@@ -9,6 +11,7 @@ define wp::command (
 		cwd => $location,
 		user => $::wp::user,
 		require => [ Class['wp::cli'] ],
-		onlyif => '/usr/bin/wp core is-installed'
+		onlyif => concat( ['/usr/bin/wp core is-installed'], $onlyif ),
+		unless => $unless,
 	}
 }

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -2,17 +2,41 @@ define wp::plugin (
 	$slug = $title,
 	$location,
 	$ensure = enabled,
-	$networkwide = false
+	$activate = true,
+	$networkwide = false,
 ) {
 	include wp::cli
 
+	$network_activate_string = $networkwide ? {
+		true  => '-network',
+		false => '',
+	}
+
+	$network_string = $networkwide ? {
+		true  => ' --network',
+		false => '',
+	}
+
+	$activate_string = $activate ? {
+		true  => join([' --activate', $network_string], ''),
+		false => '',
+	}
+
 	case $ensure {
+		present: {
+			$command = "install $slug$activate_string"
+			$unless  = ["/usr/bin/wp plugin is-installed $slug"]
+		}
+		activated: {
+			$command = "activate $slug$network_string"
+			$onlyif  = ["/usr/bin/wp plugin is-installed $slug"]
+		}
 		enabled: {
 			$command = "activate $slug"
 
 			exec { "wp install plugin $title":
 				cwd     => $location,
-				user    => $::wp::user,				
+				user    => $::wp::user,
 				command => "/usr/bin/wp plugin install $slug",
 				unless  => "/usr/bin/wp plugin is-installed $slug",
 				before  => Wp::Command["$location plugin $slug $ensure"],
@@ -21,21 +45,18 @@ define wp::plugin (
 			}
 		}
 		disabled: {
-			$command = "deactivate $slug"
+			$command = "deactivate $slug$network_string"
+			$onlyif  = ["/usr/bin/wp plugin is-installed $slug"]
 		}
 		default: {
 			fail("Invalid ensure for wp::plugin")
 		}
 	}
 
-	if $networkwide {
-		$args = "plugin $command --network"
-	}
-	else {
-		$args = "plugin $command"
-	}
 	wp::command { "$location plugin $slug $ensure":
 		location => $location,
-		command => $args
+		command  => "plugin $command",
+		onlyif   => $onlyif,
+		unless   => $unless,
 	}
 }

--- a/manifests/theme.pp
+++ b/manifests/theme.pp
@@ -1,20 +1,48 @@
 define wp::theme (
+	$slug     = $title,
 	$location,
-	$ensure = enabled
+	$ensure   = enabled,
+	$activate = false,
+	$network  = false,
 ) {
 	#$name = $title,
 	include wp::cli
 
+	$activated_param = $activate ? {
+		true  => '--activate',
+		false => ''
+	}
+
 	case $ensure {
+		present: {
+			$command = "install $slug$activated_param"
+			$unless  = ["/usr/bin/wp theme is-installed $slug"]
+		}
+		activated: {
+			$command = "activate $slug"
+			$unless  = ["/usr/bin/wp theme status $slug | grep Active"]
+			$onlyif  = ["/usr/bin/wp theme is-installed $slug"]
+		}
 		enabled: {
-			$command = "activate $title"
+			if $network {
+				$command = "enable $slug --network$activated_param"
+				$onlyif  = ["/usr/bin/wp theme is-installed $slug"]
+			} else {
+				# For backward compatibility
+				$command = "activate $slug"
+				$onlyif  = ["/usr/bin/wp theme is-installed $slug"]
+				$unless  = ["/usr/bin/wp theme status $slug | grep Active"]
+			}
 		}
 		default: {
 			fail("Invalid ensure for wp::theme")
 		}
 	}
+
 	wp::command { "$location theme $command":
 		location => $location,
-		command => "theme $command"
+		command  => "theme $command",
+		onlyif   => $onlyif,
+		unless   => $unless,
 	}
 }


### PR DESCRIPTION
Related #33, ref: https://github.com/Chassis/Chassis/pull/210#discussion_r71981437
### Changes:
- Allow installing a theme and activating it for the first time only, skips if the theme is already installed
- Allow enabling a theme site-wide, and activating it
- Ignores activation if the theme is already activated
- Ignore activation is the theme is not installed

Also
- Allow passing onlyif/unless attributes to wp::command
### New possible syntax:

```
# Installs plugins, activates them, but only after installing, not after each provision
wp::plugin { $plugins:
    location => $location,
    ensure   => 'present',
    activate => true # default
    networkwide => false # default
}

# Installs themes, does not activate them
wp::theme { $themes:
    location => $location,
    ensure   => 'present',
    activate => false # default
}

# Installs a themes, activates it after installing only, not after each provision
wp::theme { $theme:
    location => $location,
    ensure   => 'present',
    activate => true
}

# Enables a theme network wide, does not install it
wp::theme { $theme:
    slug     => $theme,
    location => $location,
    ensure   => 'enabled',
    networkwide  => false # default
}
```

_Note:_ I've tried to do it so it maintains backward compatibility, might need a fresh pair of eyes though to confirm.
