### PR TITLE
make the path for the wp binary configurable

### DIFF
--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -5,6 +5,8 @@ class wp::cli (
 ) {
 	include wp
 
+  $bin_path = $wp::params::bin_path
+
 	$phpprefix = $::operatingsystem ? {
 		'RedHat'		=> 'php',
 		'CentOS'		=> 'php',
@@ -33,14 +35,14 @@ class wp::cli (
 		}
 
 		# Symlink it across
-		file { '/usr/bin/wp':
+		file { "${bin_path}/wp":
 			ensure => link,
 			target => "$install_path/bin/wp",
 			require => File[ "$install_path/bin/wp" ],
 		}
 	}
 	elsif 'absent' == $ensure {
-		file { "/usr/bin/wp":
+		file { "${bin_path}/wp":
 			ensure => absent,
 		}
 		file { "/usr/local/src/wp-cli":

--- a/manifests/command.pp
+++ b/manifests/command.pp
@@ -3,12 +3,13 @@ define wp::command (
 	$command
 ) {
 	include wp::cli
+  include wp::params
 
 	exec {"$location wp $command":
-		command => "/usr/bin/wp $command",
+		command => "${wp::params::bin_path}/wp $command",
 		cwd => $location,
 		user => $::wp::user,
 		require => [ Class['wp::cli'] ],
-		onlyif => '/usr/bin/wp core is-installed'
+		onlyif => "${wp::params::bin_path}/wp core is-installed"
 	}
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,4 +1,4 @@
 class wp::params {
-	$user = 'www-data',
+	$user = 'www-data'
   $bin_path = '/usr/local/bin'
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,4 +1,4 @@
 class wp::params {
 	$user = 'www-data',
-  $bin_path = '/usr/local/bin',
+  $bin_path = '/usr/local/bin'
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,3 +1,4 @@
 class wp::params {
-	$user = 'www-data'
+	$user = 'www-data',
+  $bin_path = '/usr/local/bin',
 }

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -5,6 +5,7 @@ define wp::plugin (
 	$networkwide = false
 ) {
 	include wp::cli
+  include wp::params
 
 	case $ensure {
 		enabled: {
@@ -12,11 +13,11 @@ define wp::plugin (
 
 			exec { "wp install plugin $title":
 				cwd     => $location,
-				command => "/usr/bin/wp plugin install $slug",
-				unless  => "/usr/bin/wp plugin is-installed $slug",
+				command => "${wp::params::bin_path}/wp plugin install $slug",
+				unless  => "${wp::params::bin_path}/wp plugin is-installed $slug",
 				before  => Wp::Command["$location plugin $slug $ensure"],
 				require => Class["wp::cli"],
-				onlyif  => "/usr/bin/wp core is-installed"
+				onlyif  => "${wp::params::bin_path}/wp core is-installed"
 			}
 		}
 		disabled: {

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -31,37 +31,37 @@ define wp::plugin (
 			exec { "wp deactivate plugin $title$network$held":
 				cwd     => $location,
 				user    => $::wp::user,
-				command => "/usr/bin/wp plugin deactivate $slug",
+				command => "${wp::params::bin_path}/ plugin deactivate $slug",
 				require => Class["wp::cli"],
-				onlyif  => "/usr/bin/wp core is-installed"
+				onlyif  => "${wp::params::bin_path}/ core is-installed"
 			}
 		}
 		installed: {
 			exec { "wp install plugin $title$network$held":
 				cwd     => $location,
 				user    => $::wp::user,
-				command => "/usr/bin/wp plugin install $slug --activate $held",
-				unless  => "/usr/bin/wp plugin is-installed $slug",
+				command => "${wp::params::bin_path}/ plugin install $slug --activate $held",
+				unless  => "${wp::params::bin_path}/ plugin is-installed $slug",
 				require => Class["wp::cli"],
-				onlyif  => "/usr/bin/wp core is-installed"
+				onlyif  => "${wp::params::bin_path}/ core is-installed"
 			}
 		}
 		deleted: {
 			exec { "wp delete plugin $title":
 				cwd     => $location,
 				user    => $::wp::user,
-				command => "/usr/bin/wp plugin delete $slug",
+				command => "${wp::params::bin_path}/ plugin delete $slug",
 				require => Class["wp::cli"],
-				onlyif  => "/usr/bin/wp core is-installed"
+				onlyif  => "${wp::params::bin_path}/ core is-installed"
 			}
 		}
 		uninstalled: {
 			exec { "wp uninstall plugin $title":
 				cwd     => $location,
 				user    => $::wp::user,
-				command => "/usr/bin/wp plugin uninstall $slug --deactivate",
+				command => "${wp::params::bin_path}/ plugin uninstall $slug --deactivate",
 				require => Class["wp::cli"],
-				onlyif  => "/usr/bin/wp core is-installed"
+				onlyif  => "${wp::params::bin_path}/ core is-installed"
 			}
 		}
 		default: {

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -31,37 +31,37 @@ define wp::plugin (
 			exec { "wp deactivate plugin $title$network$held":
 				cwd     => $location,
 				user    => $::wp::user,
-				command => "${wp::params::bin_path}/ plugin deactivate $slug",
+				command => "${wp::params::bin_path}/wp plugin deactivate $slug",
 				require => Class["wp::cli"],
-				onlyif  => "${wp::params::bin_path}/ core is-installed"
+				onlyif  => "${wp::params::bin_path}/wp core is-installed"
 			}
 		}
 		installed: {
 			exec { "wp install plugin $title$network$held":
 				cwd     => $location,
 				user    => $::wp::user,
-				command => "${wp::params::bin_path}/ plugin install $slug --activate $held",
-				unless  => "${wp::params::bin_path}/ plugin is-installed $slug",
+				command => "${wp::params::bin_path}/wp plugin install $slug --activate $held",
+				unless  => "${wp::params::bin_path}/wp plugin is-installed $slug",
 				require => Class["wp::cli"],
-				onlyif  => "${wp::params::bin_path}/ core is-installed"
+				onlyif  => "${wp::params::bin_path}/wp core is-installed"
 			}
 		}
 		deleted: {
 			exec { "wp delete plugin $title":
 				cwd     => $location,
 				user    => $::wp::user,
-				command => "${wp::params::bin_path}/ plugin delete $slug",
+				command => "${wp::params::bin_path}/wp plugin delete $slug",
 				require => Class["wp::cli"],
-				onlyif  => "${wp::params::bin_path}/ core is-installed"
+				onlyif  => "${wp::params::bin_path}/wp core is-installed"
 			}
 		}
 		uninstalled: {
 			exec { "wp uninstall plugin $title":
 				cwd     => $location,
 				user    => $::wp::user,
-				command => "${wp::params::bin_path}/ plugin uninstall $slug --deactivate",
+				command => "${wp::params::bin_path}/wp plugin uninstall $slug --deactivate",
 				require => Class["wp::cli"],
-				onlyif  => "${wp::params::bin_path}/ core is-installed"
+				onlyif  => "${wp::params::bin_path}/wp core is-installed"
 			}
 		}
 		default: {

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -7,7 +7,8 @@ define wp::site (
 	$admin_email    = 'admin@example.com',
 	$admin_password = 'password',
 	$network        = false,
-	$subdomains     = false
+	$subdomains     = false,
+	$user           = $::wp::user,
 ) {
 	include wp::cli
 
@@ -24,7 +25,7 @@ define wp::site (
 	exec {"wp install $location":
 		command => "/usr/bin/wp core $install --title='$sitename' --admin_email='$admin_email' --admin_name='$admin_user' --admin_password='$admin_password'",
 		cwd => $location,
-		user => $::wp::user,
+		user => $user,
 		require => [ Class['wp::cli'] ],
 		unless => '/usr/bin/wp core is-installed'
 	}
@@ -33,7 +34,7 @@ define wp::site (
 		wp::option {"wp siteurl $location":
 			location => $location,
 			ensure => "equal",
-			user => $::wp::user,
+			user => $user,
 
 			key => "siteurl",
 			value => $siteurl

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -11,6 +11,7 @@ define wp::site (
 	$user           = $::wp::user,
 ) {
 	include wp::cli
+	include wp::params
 
 	if ( $network == true ) and ( $subdomains == true ) {
 		$install = "multisite-install --subdomains --url='$url'"
@@ -23,11 +24,11 @@ define wp::site (
 	}
 
 	exec {"wp install $location":
-		command => "/usr/bin/wp core $install --title='$sitename' --admin_email='$admin_email' --admin_name='$admin_user' --admin_password='$admin_password'",
+		command => "${wp::params::bin_path}/wp core $install --title='$sitename' --admin_email='$admin_email' --admin_name='$admin_user' --admin_password='$admin_password'",
 		cwd => $location,
 		user => $user,
 		require => [ Class['wp::cli'] ],
-		unless => '/usr/bin/wp core is-installed'
+		unless => "${wp::params::bin_path}/wp core is-installed"
 	}
 
 	if $siteurl != $url {


### PR DESCRIPTION
/usr (and /usr/bin) are for package managers; it's poor form to install non-package-manager things there.