### PR TITLE
Convert to network

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -13,12 +13,27 @@ define wp::site (
 
 	if ( $network == true ) and ( $subdomains == true ) {
 		$install = "multisite-install --subdomains --url='$url'"
+		$convert = "multisite-convert --subdomains --url='$url'"
 	}
 	elsif ( $network == true ) {
 		$install = "multisite-install --url='$url'"
+		$convert = "multisite-convert --url='$url'"
 	}
 	else {
 		$install = "install --url='$url'"
+	}
+
+	if ( $network ) {
+		exec {"wp multisite-convert $location":
+			command => "/usr/bin/wp core $convert",
+			cwd => $location,
+			logoutput => true,
+			user => $::wp::user,
+			require => [ Class['wp::cli'] ],
+			before => [ Exec[ "wp install $location" ] ],
+			onlyif => '/usr/bin/wp core is-installed',
+			unless => '/usr/bin/wp core is-installed --network',
+		}
 	}
 
 	exec {"wp install $location":

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -14,35 +14,34 @@ define wp::site (
 
 	if ( $network == true ) and ( $subdomains == true ) {
 		$install = "multisite-install --subdomains --url='$url'"
-		$convert = "multisite-convert --subdomains --url='$url'"
 	}
 	elsif ( $network == true ) {
 		$install = "multisite-install --url='$url'"
-		$convert = "multisite-convert --url='$url'"
 	}
 	else {
-		$install = "install --url='$url'"
+		$install     = "install --url='$url'"
+		$new_install = true
 	}
 
-	if ( $network ) {
-		exec {"wp multisite-convert $location":
-			command => "/usr/bin/wp core $convert",
-			cwd => $location,
-			logoutput => true,
-			user => $::wp::user,
+	if ( $new_install == true ) {
+		exec { "wp install $location":
+			command => "/usr/bin/wp core $install --title='$sitename
+				' --admin_email='$admin_email' --admin_name='$admin_user
+				' --admin_password='$admin_password'",
+			cwd     => $location,
+			user    => $user,
 			require => [ Class['wp::cli'] ],
-			before => [ Exec[ "wp install $location" ] ],
-			onlyif => '/usr/bin/wp core is-installed',
-			unless => '/usr/bin/wp core is-installed --network',
+			unless  => '/usr/bin/wp core is-installed'
 		}
-	}
-
-	exec {"wp install $location":
-		command => "/usr/bin/wp core $install --title='$sitename' --admin_email='$admin_email' --admin_name='$admin_user' --admin_password='$admin_password'",
-		cwd => $location,
-		user => $user,
-		require => [ Class['wp::cli'] ],
-		unless => '/usr/bin/wp core is-installed'
+	} else {
+		exec { "wp install $location":
+			command => "/usr/bin/wp core $install --title='$sitename
+				' --admin_email='$admin_email' --admin_name='$admin_user
+				' --admin_password='$admin_password'",
+			cwd     => $location,
+			user    => $user,
+			require => [ Class['wp::cli'] ],
+		}
 	}
 
 	if $siteurl != $url {


### PR DESCRIPTION
This is for #36.

I tried a few ways of trying to fix this in the past and could never get `wp core multisite-convert` to do what we wanted. However using this code I managed to do the following in using this in this [Chassis PR](https://github.com/Chassis/Chassis/pull/476):

- [x] Switch from a single site to `multisite: Yes`
- [x] Switch back from `multisite: Yes` to a single site
- [x] Switch from single site to `multisite: subdomains`
- [x] Switch back from `multisite: subdomains` to a single site

After each `vagrant provision` had completed for those items I also ran a second `vagrant provision` just to see if anything changed again or failed and it didn't.

When I set up the original single site I also imported the theme unit test data to check to see if the data persisted when I changed to multisite and it did which was great.

Feel free to test it as well and also let me know if there's something I haven't thought about or missed with this.