### PR TITLE
Add support for 'wp option patch' to be able to add, update and remove nested values in options too

### DIFF
--- a/manifests/option/patch.pp
+++ b/manifests/option/patch.pp
@@ -1,0 +1,36 @@
+# A class for WordPress option patch subcommand.
+define wp::option::patch (
+	$location,
+	$key       = $title,
+	$key_path  = undef,
+	$value     = undef,
+	$ensure    = present,
+	$format    = 'plaintext',
+	$user      = $::wp::user,
+) {
+	include wp::cli
+
+	case $ensure {
+		present: {
+			$command = "insert ${key} ${key_path} ${value} --format=${format}"
+		}
+		equal: {
+			if $value == undef {
+				fail('Option value must be specified')
+			}
+			$command = "update ${key} ${key_path} ${value}"
+		}
+		absent: {
+			$command = "delete ${key} ${key_path}"
+		}
+		default: {
+			fail('Invalid option operation')
+		}
+	}
+
+	wp::command { "${location} option patch ${command}":
+		location => $location,
+		command  => "option patch ${command}",
+		user     => $user,
+	}
+}


### PR DESCRIPTION
Hi @BronsonQuick!
Here is the pull request that adds support for the new [`wp option patch`](https://developer.wordpress.org/cli/commands/option/patch/) functionality in WP-CLI that I mentioned in #141. This is a very straight forward modification of your code. I've simply added a new `wp::option::patch` type that is basically a copy of your `wp::option` type with some modifications. Here is an example of  how it's used:

```puppet
  wp::option::patch { 'my_array':
    ensure   => 'equal',
    key_path => 'my_key_in_array',
    value    => 'my_new_value',
    location => $wp_install_dir,
  }
```

I've verified that all operations (present, equal and absent) works fine on both Linux and Windows and I'm already using this to manage my WordPress installations.

I'd really like to have this merged to your repo. If you have any questions or suggestions just let me know 🙂