### PR TITLE
feat: use nightly build of wp-cli to fix compatibility issue with php 8.5

### DIFF
--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -5,7 +5,7 @@ class wp::cli (
 	$version      = 'dev-master',
 
 ) inherits wp {
-	if $::osfamily == 'Windows' {
+	if $facts['os']['family'] == 'Windows' {
 		Package { provider => 'chocolatey' }
 	}
 

--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -2,7 +2,7 @@
 class wp::cli (
 	$ensure       = 'installed',
 	$install_path = '/usr/local/src/wp-cli',
-	$version      = 'dev-master',
+	$version      = 'dev-main',
 
 ) inherits wp {
 	if $facts['os']['family'] == 'Windows' {
@@ -17,7 +17,7 @@ class wp::cli (
 
 		archive { 'wp-cli download':
 			ensure => present,
-			source => 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar',
+			source => 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar',
 			path   => "${install_path}/bin/wp-cli.phar",
 		}
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,20 +1,20 @@
 # A class for parameters we might need to use.
 class wp::params {
-	$user = $::operatingsystem ? {
+	$user = $facts['os']['name'] ? {
 		'windows' => undef,
 		default   => 'www-data',
 	}
 	$bin_path = '/usr/local/bin'
-	$executable_filename = $::operatingsystem ? {
+	$executable_filename = $facts['os']['name'] ? {
 		'windows' => 'wp.bat',
 		default   => 'wp',
 	}
-	$php_package = $::operatingsystem ? {
+	$php_package = $facts['os']['name'] ? {
 		/^(Debian|Ubuntu)$/ => 'php5-cli',
 		'windows'           => 'php',
 		default             => 'php-cli',
 	}
-	$php_executable_path = $::operatingsystem ? {
+	$php_executable_path = $facts['os']['name'] ? {
 		'windows' => 'C:/tools/php80/php.exe',
 		default   => '/usr/bin/php',
 	}

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -39,7 +39,7 @@ define wp::plugin (
 			$unless_check = "${wp::params::bin_path}/wp plugin is-installed ${slug}"
 		}
 		disabled: {
-			$command = "${wp::params::bin_path}/wp plugin deactivate ${slug}"
+			$command = "deactivate ${slug}"
 		}
 		installed: {
 			$command = "install ${slug} ${held}"


### PR DESCRIPTION
Until the stable version of wp-cli is updated we want to use the nightly build that has a fix for php 8.5 compatibility issues.